### PR TITLE
[refactor/#22] update date/time display

### DIFF
--- a/src/pages/ChatRoom/components/MessageItem.tsx
+++ b/src/pages/ChatRoom/components/MessageItem.tsx
@@ -12,6 +12,8 @@ export default function MessageItem({ message }: MessageItemProps) {
   const { senderEmail, originalMessage, translatedMessage, sendAt } = message;
   const isUser = senderEmail === userData?.email;
 
+  const { timePart } = formatMessageTime(sendAt);
+
   const messageAlignStyle = isUser ? 'items-end' : 'items-start';
   const baseMessageStyle =
     'body-16 max-w-[75%] px-[1.5rem] py-[1rem] rounded-[2rem]';
@@ -36,9 +38,7 @@ export default function MessageItem({ message }: MessageItemProps) {
         )} */}
         <div className={translatedMessageStyle}>{translatedMessage}</div>
       </div>
-      <span className='text-grayscale-4 px-[1rem]'>
-        {formatMessageTime(sendAt)}
-      </span>
+      <span className='text-grayscale-4 body-12 px-[1rem]'>{timePart}</span>
     </div>
   );
 }

--- a/src/pages/ChatRoom/components/MessageList.tsx
+++ b/src/pages/ChatRoom/components/MessageList.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from 'react-i18next';
+
+import Loading from '@components/Loading';
+import { formatMessageTime } from '@utils/time';
 import MessageItem from '@pages/ChatRoom/components/MessageItem';
 import useChatHistoryQuery from '@pages/ChatRoom/hooks/use-chat-history-query';
-import Loading from '@components/Loading';
+import { getIsFirstOfDay } from '@pages/ChatRoom/utils/get-is-first-of-day';
 
 interface MessageListProps {
   chatRoomId: string;
@@ -13,18 +16,33 @@ export default function MessageList({ chatRoomId }: MessageListProps) {
     useChatHistoryQuery(chatRoomId);
   const reversed = [...chatHistory].reverse();
 
+  const renderDateLabel = (date: string) => {
+    return (
+      <div className='flex w-full justify-center'>
+        <span className='body-14 bg-grayscale-3 text-grayscale-6 my-[1rem] block w-fit rounded-full px-[3.5rem] py-[0.5rem] text-center'>
+          {date}
+        </span>
+      </div>
+    );
+  };
+
   return (
     <>
       {chatHistory.length !== 0 ? (
-        <div className='flex w-full flex-col gap-[1.5rem] p-[1.5rem] pb-[8rem]'>
+        <div className='flex w-full flex-col gap-[1.8rem] px-[1.5rem] pt-[1rem] pb-[8rem]'>
           {isFetchingNextPage && <Loading />}
           {reversed.map((message, index) => {
             const isTopItem = index === 0;
+
+            const { datePart } = formatMessageTime(message.sendAt);
+            const isFirstOfDay = getIsFirstOfDay(reversed, index);
+
             return (
               <div
                 key={message.chatId}
                 ref={isTopItem ? listTopRef : undefined}
               >
+                {isFirstOfDay && renderDateLabel(datePart)}
                 <MessageItem message={message} />
               </div>
             );

--- a/src/pages/ChatRoom/utils/get-is-first-of-day.ts
+++ b/src/pages/ChatRoom/utils/get-is-first-of-day.ts
@@ -1,0 +1,13 @@
+import type { MessageType } from '@type/message';
+import { formatMessageTime } from '@utils/time';
+
+export const getIsFirstOfDay = (messages: MessageType[], index: number) => {
+  const currentDate = formatMessageTime(messages[index].sendAt).datePart;
+
+  const prevMessage = messages[index - 1];
+  const prevDate = prevMessage
+    ? formatMessageTime(prevMessage.sendAt).datePart
+    : null;
+
+  return currentDate !== prevDate;
+};

--- a/src/pages/ChatRoom/utils/get-is-first-of-day.ts
+++ b/src/pages/ChatRoom/utils/get-is-first-of-day.ts
@@ -2,12 +2,14 @@ import type { MessageType } from '@type/message';
 import { formatMessageTime } from '@utils/time';
 
 export const getIsFirstOfDay = (messages: MessageType[], index: number) => {
+  if (index < 0 || index >= messages.length) {
+    return false;
+  }
+
   const currentDate = formatMessageTime(messages[index].sendAt).datePart;
 
   const prevMessage = messages[index - 1];
-  const prevDate = prevMessage
-    ? formatMessageTime(prevMessage.sendAt).datePart
-    : null;
+  const prevDate = formatMessageTime(prevMessage.sendAt).datePart;
 
   return currentDate !== prevDate;
 };

--- a/src/pages/ChatRoom/utils/get-is-first-of-day.ts
+++ b/src/pages/ChatRoom/utils/get-is-first-of-day.ts
@@ -8,6 +8,10 @@ export const getIsFirstOfDay = (messages: MessageType[], index: number) => {
 
   const currentDate = formatMessageTime(messages[index].sendAt).datePart;
 
+  if (index === 0) {
+    return true;
+  }
+
   const prevMessage = messages[index - 1];
   const prevDate = formatMessageTime(prevMessage.sendAt).datePart;
 

--- a/src/pages/Home/components/ChatItem.tsx
+++ b/src/pages/Home/components/ChatItem.tsx
@@ -1,7 +1,9 @@
+import { useNavigate } from 'react-router-dom';
+
 import { ROUTES } from '@router/routes';
 import type { ChatRoomType } from '@type/room';
-import { formatMessageTime } from '@utils/time';
-import { useNavigate } from 'react-router-dom';
+import { formatLanguage } from '@pages/Home/utils/format-language';
+import { formatMessageTime, isToday } from '@utils/time';
 
 interface ChatItemProps {
   chat: ChatRoomType;
@@ -21,25 +23,10 @@ export default function ChatItem({ chat }: ChatItemProps) {
     unreadMessageCount,
   } = chat;
 
+  const { datePart, timePart } = formatMessageTime(recentMessageTime);
+
   const handleToChatRoom = () => {
     navigate(`${ROUTES.CHAT_ROOM}/${chatroomId}`);
-  };
-
-  const formatLanguage = (language: string): string => {
-    switch (language) {
-      case 'ko':
-        return 'Korean';
-      case 'en-us':
-        return 'English';
-      case 'ja':
-        return 'Japanese';
-      case 'zh':
-        return 'Chinese';
-      case 'es':
-        return 'Spanish';
-      default:
-        return language;
-    }
   };
 
   return (
@@ -64,7 +51,7 @@ export default function ChatItem({ chat }: ChatItemProps) {
             </div>
             {recentMessageTime && (
               <span className='body-14 text-grayscale-4'>
-                {formatMessageTime(recentMessageTime)}
+                {isToday(recentMessageTime) ? timePart : datePart}
               </span>
             )}
           </div>

--- a/src/pages/Home/utils/format-language.ts
+++ b/src/pages/Home/utils/format-language.ts
@@ -1,0 +1,16 @@
+export const formatLanguage = (language: string): string => {
+  switch (language) {
+    case 'ko':
+      return 'Korean';
+    case 'en-us':
+      return 'English';
+    case 'ja':
+      return 'Japanese';
+    case 'zh':
+      return 'Chinese';
+    case 'es':
+      return 'Spanish';
+    default:
+      return language;
+  }
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,12 +1,23 @@
 export const formatMessageTime = (isoString: string) => {
   const date = new Date(isoString);
 
-  return date.toLocaleString(undefined, {
+  const datePart = date.toLocaleDateString(undefined, {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
+  });
+
+  const timePart = date.toLocaleTimeString(undefined, {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
   });
+
+  return { datePart, timePart };
+};
+
+export const isToday = (isoString: string) => {
+  const currentDate = new Date();
+  const messageDate = new Date(isoString);
+  return currentDate.getDate() === messageDate.getDate();
 };

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -17,7 +17,8 @@ export const formatMessageTime = (isoString: string) => {
 };
 
 export const isToday = (isoString: string) => {
-  const currentDate = new Date();
+  const today = new Date();
   const messageDate = new Date(isoString);
-  return currentDate.getDate() === messageDate.getDate();
+
+  return today.toDateString() === messageDate.toDateString();
 };


### PR DESCRIPTION
## 🔗 Issue Number

close #22 

## 📝 Work detail

- Updated `formatMessageTime` to return both `datePart` and `timePart` separately.

- In the `Home` page, added logic to determine whether the last message time is from today.
   - If it is today, display the time; otherwise, display the date.
   - Used `isToday` to check whether the timestamp corresponds to the current day.

- In the `ChatRoom` page, added logic to compare each message with the previous one to determine if the date has changed (i.e., the first message of the day).
   - Used `getIsFirstOfDay` to return a `boolean`, and if true, display the date divider

- Extracted formatLanguage into a separate utility.

## 📸 Screenshots

<img width="386" height="490" alt="image" src="https://github.com/user-attachments/assets/730bbe64-f60c-4671-b76f-2c6a79c89a3c" />
<img width="393" height="511" alt="image" src="https://github.com/user-attachments/assets/cdf6adb4-0906-43dc-8292-b898578ed587" />
<img width="400" height="334" alt="image" src="https://github.com/user-attachments/assets/c334b14f-6aa3-437a-a026-a71b1376e511" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date separators in chat messages to clearly distinguish conversations across different days.

* **Improvements**
  * Enhanced timestamp display logic with better date and time formatting organization.
  * Improved language name display across the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->